### PR TITLE
Refactor/result/change getter private

### DIFF
--- a/src/main/java/baseball/Application.java
+++ b/src/main/java/baseball/Application.java
@@ -7,7 +7,7 @@ public class Application {
         try {
             Game game = new Game();
             game.startGame();
-        }finally {
+        } finally {
             Console.close();
         }
     }

--- a/src/main/java/baseball/Computer.java
+++ b/src/main/java/baseball/Computer.java
@@ -1,22 +1,24 @@
 package baseball;
 
 import camp.nextstep.edu.missionutils.Randoms;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class Computer {
-    private List<Integer> answer;
+    public static final int ANSWER_SIZE = 3;
+    public static final int RANGE_START = 1;
+    public static final int RANGE_END = 9;
 
+    private List<Integer> answer;
 
     /**
      * answer에 서로 다른 3개의 정수를 가진 List<Integer>을 저장
      */
-    public void init(){
+    public void init() {
         answer = new ArrayList<>();
-        while(answer.size() < 3){
-            int randomNumber = Randoms.pickNumberInRange(1, 9);
-            if(!answer.contains(randomNumber)) {
+        while (answer.size() < ANSWER_SIZE) {
+            int randomNumber = Randoms.pickNumberInRange(RANGE_START, RANGE_END);
+            if (!answer.contains(randomNumber)) {
                 answer.add(randomNumber);
             }
         }
@@ -24,12 +26,14 @@ public class Computer {
 
     /**
      * 사용자의 입력에 대한 결과 반환
+     *
      * @param input 사용자가 입력한 서로 다른 3개의 숫자 리스트
      * @return 사용자의 입력과 answer를 비교한 결과 리스트
      */
-    public Result getResult(List<Integer> input){
+    public Result getResult(List<Integer> input) {
+
         Result result = new Result();
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < ANSWER_SIZE; i++) {
             int number = input.get(i);
             if (answer.get(i).equals(number)) {
                 result.addStrike();

--- a/src/main/java/baseball/Computer.java
+++ b/src/main/java/baseball/Computer.java
@@ -28,11 +28,6 @@ public class Computer {
      * @return 사용자의 입력과 answer를 비교한 결과 리스트
      */
     public Result getResult(List<Integer> input){
-
-        if(input.size() != 3){
-            throw new IllegalArgumentException("사용자의 입력 숫자는 정확히 3개여야 합니다.");
-        }
-
         Result result = new Result();
         for (int i = 0; i < 3; i++) {
             int number = input.get(i);

--- a/src/main/java/baseball/Game.java
+++ b/src/main/java/baseball/Game.java
@@ -24,7 +24,7 @@ public class Game {
             List<Integer> input = player.getInput();
             result = computer.getResult(input);
             System.out.println(result);
-        } while (result.getStrike() != 3);
+        } while (result.isAnswer());
         System.out.println("3개의 숫자를 모두 맞히셨습니다! 게임 종료");
     }
 }

--- a/src/main/java/baseball/Game.java
+++ b/src/main/java/baseball/Game.java
@@ -3,28 +3,28 @@ package baseball;
 import java.util.List;
 
 public class Game {
-
     Player player = new Player();
     Computer computer = new Computer();
 
-    public void startGame(){
+    public void startGame() {
         boolean restart;
         System.out.println("숫자 야구 게임을 시작합니다.");
-        do{
+        do {
             computer.init();
             play();
             System.out.println("게임을 새로 시작하려면 1, 종료하려면 2를 입력하세요.");
             restart = player.restart();
-        }while(restart);
+        } while (restart);
     }
-    public void play(){
+
+    public void play() {
         Result result;
-        do{
+        do {
             System.out.print("숫자를 입력해주세요 : ");
             List<Integer> input = player.getInput();
             result = computer.getResult(input);
             System.out.println(result);
-        }while(result.getStrike() != 3);
+        } while (result.getStrike() != 3);
         System.out.println("3개의 숫자를 모두 맞히셨습니다! 게임 종료");
     }
 }

--- a/src/main/java/baseball/Game.java
+++ b/src/main/java/baseball/Game.java
@@ -8,7 +8,7 @@ public class Game {
     Computer computer = new Computer();
 
     public void startGame(){
-        boolean restart = false;
+        boolean restart;
         System.out.println("숫자 야구 게임을 시작합니다.");
         do{
             computer.init();
@@ -16,8 +16,6 @@ public class Game {
             System.out.println("게임을 새로 시작하려면 1, 종료하려면 2를 입력하세요.");
             restart = player.restart();
         }while(restart);
-        //TODO : 종료하기 전 Console.close() 호출
-
     }
     public void play(){
         Result result;

--- a/src/main/java/baseball/Player.java
+++ b/src/main/java/baseball/Player.java
@@ -1,7 +1,6 @@
 package baseball;
 
 import camp.nextstep.edu.missionutils.Console;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,34 +9,36 @@ public class Player {
     public static final String INPUT_MUST_3_NUMBER_EXCEPTION = "입력은 3개의 정수로 이루어져 있어야 합니다.";
     public static final String INPUT_MUST_NOT_DUPLICATED_EXCEPTION = "정수는 모두 서로 달라야 합니다.";
     public static final String NUMBER_FORMAT_EXCEPTION = "숫자가 아닌 입력이 있습니다";
-    public static final String WRONG_INPUT_IN_RESTART = "잘못된 입력입니다. (재시작 : 1, 종료 : 2)";
+    public static final String WRONG_INPUT_IN_RESTART_EXCEPTION = "잘못된 입력입니다. (재시작 : 1, 종료 : 2)";
     private static int RESTART = 1;
     private static int END = 2;
 
     /**
      * 사용자에게 서로 다른 3가지 정수를 입력받는다.
+     *
      * @return 사용자가 입력한 정수를 List<Integer>에 담아 반환
      * @throws IllegalArgumentException
      */
-    public List<Integer> getInput() throws IllegalArgumentException{
+    public List<Integer> getInput() throws IllegalArgumentException {
         String input = Console.readLine();
         return getInput(input);
     }
 
-    public List<Integer> getInput(String input) throws IllegalArgumentException{
+    public List<Integer> getInput(String input) throws IllegalArgumentException {
         String[] tokens = input.split("");
-        if(tokens.length != 3){
+        if (tokens.length != 3) {
             throw new IllegalArgumentException(INPUT_MUST_3_NUMBER_EXCEPTION);
         }
+
         ArrayList<Integer> inputNumbers = new ArrayList<>();
-        for(int i = 0; i<3; i++){
-            try{
+        for (int i = 0; i < 3; i++) {
+            try {
                 int n = Integer.parseInt(tokens[i]);
-                if(inputNumbers.contains(n)){
+                if (inputNumbers.contains(n)) {
                     throw new IllegalArgumentException(INPUT_MUST_NOT_DUPLICATED_EXCEPTION);
                 }
                 inputNumbers.add(n);
-            }catch (NumberFormatException e){
+            } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(NUMBER_FORMAT_EXCEPTION);
             }
         }
@@ -46,26 +47,27 @@ public class Player {
 
     /**
      * 재시작 여부를 반환한다.
+     *
      * @return true - 재시작의 경우, false - 종료의 경우
      * @throws IllegalArgumentException
      */
-    public boolean restart() throws IllegalArgumentException{
+    public boolean restart() throws IllegalArgumentException {
         String input = Console.readLine();
         return restart(input);
     }
 
     //테스트를 위한 오버로딩
-    public boolean restart(String s) throws IllegalArgumentException{
+    public boolean restart(String s) throws IllegalArgumentException {
         try {
             int input = Integer.parseInt(s);
-            if(input == RESTART) {
+            if (input == RESTART) {
                 return true;
             }
             if (input == END) {
                 return false;
             }
-            throw new IllegalArgumentException(WRONG_INPUT_IN_RESTART);
-        }catch (NumberFormatException e){
+            throw new IllegalArgumentException(WRONG_INPUT_IN_RESTART_EXCEPTION);
+        } catch (NumberFormatException e) {
             throw new IllegalArgumentException(NUMBER_FORMAT_EXCEPTION);
         }
     }

--- a/src/main/java/baseball/Result.java
+++ b/src/main/java/baseball/Result.java
@@ -1,5 +1,7 @@
 package baseball;
 
+import java.util.Objects;
+
 public class Result {
     private int strike;
     private int ball;
@@ -41,11 +43,24 @@ public class Result {
         this.ball++;
     }
 
-    public int getStrike() {
-        return strike;
+    public boolean isAnswer() {
+        return this.strike == 3;
     }
 
-    public int getBall() {
-        return ball;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Result result = (Result) o;
+        return strike == result.strike && ball == result.ball;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(strike, ball);
     }
 }

--- a/src/main/java/baseball/Result.java
+++ b/src/main/java/baseball/Result.java
@@ -16,26 +16,28 @@ public class Result {
 
     @Override
     public String toString() {
-        if(strike + ball == 0){
+        if (strike + ball == 0) {
             return "낫싱";
         }
         StringBuilder result = new StringBuilder();
-        if(ball != 0){
+        if (ball != 0) {
             result.append(ball + "볼");
         }
         if (strike != 0) {
-            if(!result.isEmpty())
+            if (!result.isEmpty()) {
                 result.append(" ");
+            }
             result.append(strike + "스트라이크");
         }
 
         return result.toString();
     }
 
-    public void addStrike(){
+    public void addStrike() {
         this.strike++;
     }
-    public void addBall(){
+
+    public void addBall() {
         this.ball++;
     }
 

--- a/src/test/java/baseball/ComputerTest.java
+++ b/src/test/java/baseball/ComputerTest.java
@@ -1,16 +1,17 @@
 package baseball;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Test;
-
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class ComputerTest {
 
     @Test
-    public void initTest() throws Exception{
+    public void initTest() throws Exception {
         //given
         Computer computer = new Computer();
 
@@ -29,8 +30,9 @@ class ComputerTest {
                     .isEqualTo(3);
         }
     }
+
     @Test
-    public void getResultTest1() throws Exception{
+    public void getResultTest1() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{1, 2, 3});
@@ -39,16 +41,12 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{1, 2, 3});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(3);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(0);
+        isEqualsResult(result, 3, 0);
     }
 
     @Test
-    public void getResultTest2() throws Exception{
+    public void getResultTest2() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{1, 2, 3});
@@ -57,16 +55,12 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{2, 1, 3});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(1);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(2);
+        isEqualsResult(result, 1, 2);
     }
 
     @Test
-    public void getResultTest3() throws Exception{
+    public void getResultTest3() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{1, 2, 3});
@@ -75,16 +69,12 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{5, 4, 3});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(1);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(0);
+        isEqualsResult(result, 1, 0);
     }
 
     @Test
-    public void getResultTest4() throws Exception{
+    public void getResultTest4() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{1, 2, 3});
@@ -93,17 +83,14 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{5, 6, 7});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(0);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(0);
+        isEqualsResult(result, 0, 0);
     }
 
     //== 예시 테스트 ==//
+
     @Test
-    public void getResultTest5() throws Exception{
+    public void getResultTest5() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{7, 1, 3});
@@ -112,16 +99,13 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{1, 2, 3});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(1);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(1);
+
+        isEqualsResult(result, 1, 1);
     }
 
     @Test
-    public void getResultTest6() throws Exception{
+    public void getResultTest6() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{7, 1, 3});
@@ -130,16 +114,13 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{1, 4, 5});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(0);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(1);
+
+        isEqualsResult(result, 0, 1);
     }
 
     @Test
-    public void getResultTest7() throws Exception{
+    public void getResultTest7() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{7, 1, 3});
@@ -148,16 +129,13 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{6, 7, 1});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(0);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(2);
+
+        isEqualsResult(result, 0, 2);
     }
 
     @Test
-    public void getResultTest8() throws Exception{
+    public void getResultTest8() throws Exception {
         //given
         Computer computer = new Computer();
         computer.setAnswer(new int[]{7, 1, 3});
@@ -166,19 +144,21 @@ class ComputerTest {
         ArrayList<Integer> input = getUserInput(new int[]{2, 1, 6});
         Result result = computer.getResult(input);
 
-
         //then
-        Assertions.assertThat(result.getStrike())
-                .isEqualTo(1);
-        Assertions.assertThat(result.getBall())
-                .isEqualTo(0);
+
+        isEqualsResult(result, 1, 0);
     }
 
-    private ArrayList<Integer> getUserInput(int[] input){
+    private ArrayList<Integer> getUserInput(int[] input) {
         ArrayList<Integer> userInput = new ArrayList<>();
         for (int i : input) {
             userInput.add(i);
         }
         return userInput;
+    }
+
+    private ObjectAssert<Result> isEqualsResult(Result result, int strike, int ball) {
+        return Assertions.assertThat(result)
+                .isEqualTo(new Result(strike, ball));
     }
 }

--- a/src/test/java/baseball/PlayerTest.java
+++ b/src/test/java/baseball/PlayerTest.java
@@ -3,45 +3,43 @@ package baseball;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class PlayerTest {
 
     Player player = new Player();
 
     @Test
-    public void inputContains3Number() throws Exception{
+    public void inputContains3Number() throws Exception {
         //given
 
         //when
         Assertions.assertThatThrownBy(
-                () ->
-                        player.getInput("12"),
+                        () ->
+                                player.getInput("12"),
                         Player.INPUT_MUST_3_NUMBER_EXCEPTION)
                 .isInstanceOf(IllegalArgumentException.class);
         //then
     }
 
     @Test
-    public void input_must_not_duplicated() throws Exception{
+    public void input_must_not_duplicated() throws Exception {
         //given
         //when
         Assertions.assertThatThrownBy(
-                () ->
-                        player.getInput("111"),
+                        () ->
+                                player.getInput("111"),
                         Player.INPUT_MUST_NOT_DUPLICATED_EXCEPTION)
                 .isInstanceOf(IllegalArgumentException.class);
         //then
     }
 
     @Test
-    public void numeric_exception_in_getInput() throws Exception{
+    public void numeric_exception_in_getInput() throws Exception {
         //given
 
         //when
         Assertions.assertThatThrownBy(
-                ()->
-                        player.getInput("a"),
+                        () ->
+                                player.getInput("a"),
                         Player.NUMBER_FORMAT_EXCEPTION)
                 .isInstanceOf(IllegalArgumentException.class);
 
@@ -49,7 +47,7 @@ class PlayerTest {
     }
 
     @Test
-    public void success_getInput() throws Exception{
+    public void success_getInput() throws Exception {
         //given
 
         //when
@@ -60,7 +58,7 @@ class PlayerTest {
     }
 
     @Test
-    public void numericException_in_restart() throws Exception{
+    public void numericException_in_restart() throws Exception {
         //given
         //when
         Assertions.assertThatIllegalArgumentException()
@@ -71,31 +69,31 @@ class PlayerTest {
     }
 
     @Test
-    public void wrongInput_in_restart0() throws Exception{
+    public void wrongInput_in_restart0() throws Exception {
         //given
 
         //when
         Assertions.assertThatIllegalArgumentException()
                 .isThrownBy(() -> player.restart("0"))
-                .withMessage(Player.WRONG_INPUT_IN_RESTART);
+                .withMessage(Player.WRONG_INPUT_IN_RESTART_EXCEPTION);
 
         //then
     }
 
     @Test
-    public void wrongInput_in_restart_3() throws Exception{
+    public void wrongInput_in_restart_3() throws Exception {
         //given
 
         //when
         Assertions.assertThatIllegalArgumentException()
                 .isThrownBy(() -> player.restart("3"))
-                .withMessage(Player.WRONG_INPUT_IN_RESTART);
+                .withMessage(Player.WRONG_INPUT_IN_RESTART_EXCEPTION);
 
         //then
     }
 
     @Test
-    public void restart_returns_true_when_1_input() throws Exception{
+    public void restart_returns_true_when_1_input() throws Exception {
         //given
         //when
         boolean restart = player.restart("1");
@@ -106,7 +104,7 @@ class PlayerTest {
     }
 
     @Test
-    public void restart_returns_false_when_2_input() throws Exception{
+    public void restart_returns_false_when_2_input() throws Exception {
         //given
         //when
         boolean restart = player.restart("2");


### PR DESCRIPTION
## 리팩토링 근거

`Result` 객체는 결과를 나타내기 위한 객체이지만, 해당 결과가 정답인지의 여부는 `Game`이 `Result.getStrike()`를 호출하여 판단하고 있었다. <br>
결과를 나타내는 객체가 `Result`인 만큼, 정답의 판단 또한 `Result`가 직접 하는 것이 옳다는 생각이 들었고, getter를 이용한 정답 판단 로직을 수정하였다.<br>
추가로, 테스트 코드에서 제대로 된 `Result` 객체가 생성되는지 확인하는 과정에서 getter를 사용하였는데, 이 역시 `equals()` 메서드를 오버라이드 하여 예상되는 객체와 비교하여 테스트를 진행하도록 수정하였다.

- 참고 아티클
[getter를 사용하는 대신 객체에 메시지를 보내자](https://tecoble.techcourse.co.kr/post/2020-04-28-ask-instead-of-getter/)